### PR TITLE
Added option :port when opening a connection

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -72,6 +72,7 @@ module Net
 
 		def initialize display=':0', options={}
 			@server = 'localhost'
+			@server_port = options[:port] || BASE_PORT
 			if display =~ /^(.*)(:\d+)$/
 				@server, display = $1, $2
 			end
@@ -99,7 +100,7 @@ module Net
 		end
 
 		def port
-			BASE_PORT + @display
+			@server_port + @display
 		end
 
 		def connect


### PR DESCRIPTION
This is useful for accessing VNC servers that has non-standard ports, especially in the cases where multiple VNC servers need to be accessed in the same network, thus port forwarding to non-standard ports is used to avoid conflicts. 
