### PR TITLE
Add project Gemfile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+== Unreleased:
+
+- Added a project Gemfile
+
 == 1.1.0 / 2012-06-03
 
 - Fixes to support ruby 1.9 (jedi4ever & codemonkeyjohn).

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gemspec


### PR DESCRIPTION
Very simple change to add a project Gemfile, so if we need to include development gems it is easy to just bundle and get going.

I am planning on working a bit with the code quality, so it would be cool to introduce a gem like Rubocup at least initially to keep watch.