### PR TITLE
Add helpers to read/write in same language as spec

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+== Unreleased
+
+- Made helpers to read/send information from/to server
+
 == 1.1.0 / 2012-06-03
 
 - Fixes to support ruby 1.9 (jedi4ever & codemonkeyjohn).


### PR DESCRIPTION
Used the vocabulary from https://tools.ietf.org/html/rfc6143

It makes it very easy to read/write following the RFC6143, and we don't have to think about pack/unpack.

Work in progress.