### PR TITLE
Introduce Docker and Docker-compose for making better tests

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,12 @@ servers on any platform.
 
 The primary documentation is for the Net::VNC class.
 
+= Running the tests
+
+* Boot up the two VNC servers with `docker-compose up`.
+
+* Run the test-suite with `bundle exec rake spec`.
+
 = Thanks
 
 Code borrows a lot from Tim Waugh's excellent rfbplaymacro. So far all it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  ubuntuvnc:
+    image: dorowu/ubuntu-desktop-lxde-vnc
+    ports:
+      - "5901:5900"
+    environment:
+      - VNC_PASSWORD=matzisnicesowearenice
+      - RESOLUTION=1366x768
+  ubuntuvnc-nopass:
+    image: dorowu/ubuntu-desktop-lxde-vnc
+    ports:
+      - "5902:5900"
+    environment:
+      - RESOLUTION=1366x768

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
 version: "3"
 services:
-  ubuntuvnc:
+  ubuntuvnc-nopass:
     image: dorowu/ubuntu-desktop-lxde-vnc
     ports:
       - "5901:5900"
     environment:
-      - VNC_PASSWORD=matzisnicesowearenice
       - RESOLUTION=1366x768
-  ubuntuvnc-nopass:
+
+  ubuntuvnc-withpass:
     image: dorowu/ubuntu-desktop-lxde-vnc
     ports:
       - "5902:5900"
     environment:
+      - VNC_PASSWORD=matzisnicesowearenice
       - RESOLUTION=1366x768

--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -103,7 +103,7 @@ module Net
 		end
 
 		def connect
-			@socket = TCPSocket.open server, port
+			@socket = TCPSocket.open(server, port)
 			unless socket.read(12) =~ /^RFB (\d{3}.\d{3})\n$/
 				raise 'invalid server response'
 			end

--- a/spec/real_net_vnc_spec.rb
+++ b/spec/real_net_vnc_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'net/vnc'
+
+RSpec.describe Net::VNC do
+  NO_AUTH_SERVER_DISPLAY   = ':1'
+  WITH_AUTH_SERVER_DISPLAY = ':2'
+
+  context 'no auth' do
+    it 'should connect with no password' do
+      Net::VNC.open(NO_AUTH_SERVER_DISPLAY) do |vnc|
+        vnc.pointer_move(10,15)
+        expect(vnc.pointer.x).to eq 10
+        expect(vnc.pointer.y).to eq 15
+
+        vnc.pointer_move(20,25)
+        expect(vnc.pointer.x).to eq 20
+        expect(vnc.pointer.y).to eq 25
+      end
+    end
+
+    it 'should connect with password even though it is not needed' do
+      Net::VNC.open(NO_AUTH_SERVER_DISPLAY, password: 'password') do |vnc|
+        vnc.pointer_move(10,15)
+        expect(vnc.pointer.x).to eq 10
+      end
+    end
+  end
+
+  context 'with auth' do
+    it 'should connect with a password' do
+      Net::VNC.open(WITH_AUTH_SERVER_DISPLAY, password: 'matzisnicesowearenice') do |vnc|
+        vnc.pointer_move(10,15)
+        expect(vnc.pointer.x).to eq 10
+        expect(vnc.pointer.y).to eq 15
+      end
+    end
+
+    it 'should give error with a wrong password' do
+      expect { Net::VNC.open(WITH_AUTH_SERVER_DISPLAY, password: 'wrongPasssword') }.to raise_error(RuntimeError, 'Unable to authenticate - 1')
+    end
+
+    it 'should give error with no password' do
+      expect { Net::VNC.open(WITH_AUTH_SERVER_DISPLAY) }.to raise_error(RuntimeError, 'Need to authenticate but no password given')
+    end
+  end
+end


### PR DESCRIPTION
We can easily set up a couple of VNC servers with docker, and connect to them to test how the protocol handles.

The added `docker-compose`-file sets up two VNC servers on port 5901 and 5902, the first does not require a password, and the second does require a password.