### PR TITLE
Rubocop style fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,28 +11,28 @@ end
 
 desc 'Run all specs and generate html spec document'
 namespace :spec do
-	RSpec::Core::RakeTask.new :html do |t|
-		t.rspec_opts = ['--format html --out spec.html']
-	end
+  RSpec::Core::RakeTask.new :html do |t|
+    t.rspec_opts = ['--format html --out spec.html']
+  end
 end
 
 require 'rdoc/task'
 
 Rake::RDocTask.new do |t|
-	t.rdoc_dir = 'doc'
-	t.rdoc_files.include 'lib/**/*.rb'
-	t.rdoc_files.include 'README'
-	t.title = "ruby-vnc documentation"
-	t.options += %w[--line-numbers --inline-source --tab-width 2]
-	t.main = 'README'
+  t.rdoc_dir = 'doc'
+  t.rdoc_files.include 'lib/**/*.rb'
+  t.rdoc_files.include 'README'
+  t.title = "ruby-vnc documentation"
+  t.options += %w[--line-numbers --inline-source --tab-width 2]
+  t.main = 'README'
 end
 
 require 'rubygems/package_task'
 
 spec = eval File.read('ruby-vnc.gemspec')
 Gem::PackageTask.new(spec) do |pkg|
-	pkg.need_tar = false
-	pkg.need_zip = false
-	pkg.package_dir = 'build'
+  pkg.need_tar = false
+  pkg.need_zip = false
+  pkg.package_dir = 'build'
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Rake::RDocTask.new do |t|
   t.rdoc_dir = 'doc'
   t.rdoc_files.include 'lib/**/*.rb'
   t.rdoc_files.include 'README'
-  t.title = "ruby-vnc documentation"
+  t.title = 'ruby-vnc documentation'
   t.options += %w[--line-numbers --inline-source --tab-width 2]
   t.main = 'README'
 end

--- a/lib/cipher/vncdes.rb
+++ b/lib/cipher/vncdes.rb
@@ -30,7 +30,7 @@ module Cipher
   class VNCDES
     attr_reader :key
 
-    def initialize key
+    def initialize(key)
       @key = normalized(key[0..7])
       self
     end

--- a/lib/cipher/vncdes.rb
+++ b/lib/cipher/vncdes.rb
@@ -27,29 +27,29 @@ require 'openssl'
 # The protocol continues with the SecurityResult message.
 
 module Cipher
-	class VNCDES
-		attr_reader :key
+  class VNCDES
+    attr_reader :key
 
-		def initialize key
-			@key = normalized(key[0..7])
-			self
-		end
+    def initialize key
+      @key = normalized(key[0..7])
+      self
+    end
 
-		def encrypt(challenge)
-			chunks = [challenge.slice(0, 8), challenge.slice(8, 8)]
-			cipher = OpenSSL::Cipher::DES.new(:ECB)
-			cipher.encrypt
-			cipher.key = self.key
-			chunks.reduce('') { |a, e| cipher.reset; a << cipher.update(e) }.force_encoding('UTF-8')
-		end
+    def encrypt(challenge)
+      chunks = [challenge.slice(0, 8), challenge.slice(8, 8)]
+      cipher = OpenSSL::Cipher::DES.new(:ECB)
+      cipher.encrypt
+      cipher.key = self.key
+      chunks.reduce('') { |a, e| cipher.reset; a << cipher.update(e) }.force_encoding('UTF-8')
+    end
 
-		private
+    private
 
-		def normalized(key)
-			rev = ->(n) { (0...8).reduce(0) { |a, e| a + 2**e * n[7 - e] } }
-			inv = key.each_byte.map { |b| rev[b].chr }.join
-			inv.ljust(8, "\x00")
-		end
-	end
+    def normalized(key)
+      rev = ->(n) { (0...8).reduce(0) { |a, e| a + 2**e * n[7 - e] } }
+      inv = key.each_byte.map { |b| rev[b].chr }.join
+      inv.ljust(8, "\x00")
+    end
+  end
 end
 

--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -5,308 +5,308 @@ require 'cipher/vncdes'
 require 'net/vnc/version'
 
 module Net
-	#
-	# The VNC class provides for simple rfb-protocol based control of
-	# a VNC server. This can be used, eg, to automate applications.
-	#
-	# Sample usage:
-	#
-	#	  # launch xclock on localhost. note that there is an xterm in the top-left
-	#
-	#   require 'net/vnc'
-	#   Net::VNC.open 'localhost:0', :shared => true, :password => 'mypass' do |vnc|
-	#     vnc.pointer_move 10, 10
-	#     vnc.type 'xclock'
-	#     vnc.key_press :return
-	#   end
-	#
-	# = TODO
-	#
-	# * The server read loop seems a bit iffy. Not sure how best to do it.
-	# * Should probably be changed to be more of a lower-level protocol wrapping thing, with the
-	#   actual VNCClient sitting on top of that. all it should do is read/write the packets over
-	#   the socket.
-	#
-	class VNC
-		class PointerState
-			attr_reader :x, :y, :button
+  #
+  # The VNC class provides for simple rfb-protocol based control of
+  # a VNC server. This can be used, eg, to automate applications.
+  #
+  # Sample usage:
+  #
+  #   # launch xclock on localhost. note that there is an xterm in the top-left
+  #
+  #   require 'net/vnc'
+  #   Net::VNC.open 'localhost:0', :shared => true, :password => 'mypass' do |vnc|
+  #     vnc.pointer_move 10, 10
+  #     vnc.type 'xclock'
+  #     vnc.key_press :return
+  #   end
+  #
+  # = TODO
+  #
+  # * The server read loop seems a bit iffy. Not sure how best to do it.
+  # * Should probably be changed to be more of a lower-level protocol wrapping thing, with the
+  #   actual VNCClient sitting on top of that. all it should do is read/write the packets over
+  #   the socket.
+  #
+  class VNC
+    class PointerState
+      attr_reader :x, :y, :button
 
-			def initialize vnc
-				@x = @y = @button = 0
-				@vnc = vnc
-			end
+      def initialize vnc
+        @x = @y = @button = 0
+        @vnc = vnc
+      end
 
-			# could have the same for x=, and y=
-			def button= button
-				@button = button
-				refresh
-			end
+      # could have the same for x=, and y=
+      def button= button
+        @button = button
+        refresh
+      end
 
-			def update x, y, button=@button
-				@x, @y, @button = x, y, button
-				refresh
-			end
+      def update x, y, button=@button
+        @x, @y, @button = x, y, button
+        refresh
+      end
 
-			def refresh
-				packet = 0.chr * 6
-				packet[0] = 5.chr
-				packet[1] = button.chr
-				packet[2, 2] = [x].pack 'n'
-				packet[4, 2] = [y].pack 'n'
-				@vnc.socket.write packet
-			end
-		end
+      def refresh
+        packet = 0.chr * 6
+        packet[0] = 5.chr
+        packet[1] = button.chr
+        packet[2, 2] = [x].pack 'n'
+        packet[4, 2] = [y].pack 'n'
+        @vnc.socket.write packet
+      end
+    end
 
-		BASE_PORT = 5900
-		CHALLENGE_SIZE = 16
-		DEFAULT_OPTIONS = {
-			:shared => false,
-			:wait => 0.1
-		}
+    BASE_PORT = 5900
+    CHALLENGE_SIZE = 16
+    DEFAULT_OPTIONS = {
+      :shared => false,
+      :wait => 0.1
+    }
 
-		keys_file = File.dirname(__FILE__) + '/../../data/keys.yaml'
-		KEY_MAP = YAML.load_file(keys_file).inject({}) { |h, (k, v)| h.update k.to_sym => v }
-		def KEY_MAP.[] key
-			super or raise ArgumentError.new('Invalid key name - %s' % key)
-		end
+    keys_file = File.dirname(__FILE__) + '/../../data/keys.yaml'
+    KEY_MAP = YAML.load_file(keys_file).inject({}) { |h, (k, v)| h.update k.to_sym => v }
+    def KEY_MAP.[] key
+      super or raise ArgumentError.new('Invalid key name - %s' % key)
+    end
 
-		attr_reader :server, :display, :options, :socket, :pointer
+    attr_reader :server, :display, :options, :socket, :pointer
 
-		def initialize display=':0', options={}
-			@server = 'localhost'
-			if display =~ /^(.*)(:\d+)$/
-				@server, display = $1, $2
-			end
-			@display = display[1..-1].to_i
-			@options = DEFAULT_OPTIONS.merge options
-			@clipboard = nil
-			@pointer = PointerState.new self
-			@mutex = Mutex.new
-			connect
-			@packet_reading_state = nil
-			@packet_reading_thread = Thread.new { packet_reading_thread }
-		end
+    def initialize display=':0', options={}
+      @server = 'localhost'
+      if display =~ /^(.*)(:\d+)$/
+        @server, display = $1, $2
+      end
+      @display = display[1..-1].to_i
+      @options = DEFAULT_OPTIONS.merge options
+      @clipboard = nil
+      @pointer = PointerState.new self
+      @mutex = Mutex.new
+      connect
+      @packet_reading_state = nil
+      @packet_reading_thread = Thread.new { packet_reading_thread }
+    end
 
-		def self.open display=':0', options={}
-			vnc = new display, options
-			if block_given?
-				begin
-					yield vnc
-				ensure
-					vnc.close
-				end
-			else
-				vnc
-			end
-		end
+    def self.open display=':0', options={}
+      vnc = new display, options
+      if block_given?
+        begin
+          yield vnc
+        ensure
+          vnc.close
+        end
+      else
+        vnc
+      end
+    end
 
-		def port
-			BASE_PORT + @display
-		end
+    def port
+      BASE_PORT + @display
+    end
 
-		def connect
-			@socket = TCPSocket.open(server, port)
-			unless socket.read(12) =~ /^RFB (\d{3}.\d{3})\n$/
-				raise 'invalid server response'
-			end
-			@server_version = $1
-			socket.write "RFB 003.003\n"
-			data = socket.read(4)
-			auth = data.to_s.unpack('N')[0]
-			case auth
-			when 0, nil
-				raise 'connection failed'
-			when 1
-				# ok...
-			when 2
-				password = @options[:password] or raise 'Need to authenticate but no password given'
-				challenge = socket.read CHALLENGE_SIZE
-				response = Cipher::VNCDES.new(password).encrypt(challenge)
-				socket.write response
-				ok = socket.read(4).to_s.unpack('N')[0]
-				raise 'Unable to authenticate - %p' % ok unless ok == 0
-			else
-				raise 'Unknown authentication scheme - %d' % auth
-			end
+    def connect
+      @socket = TCPSocket.open(server, port)
+      unless socket.read(12) =~ /^RFB (\d{3}.\d{3})\n$/
+        raise 'invalid server response'
+      end
+      @server_version = $1
+      socket.write "RFB 003.003\n"
+      data = socket.read(4)
+      auth = data.to_s.unpack('N')[0]
+      case auth
+      when 0, nil
+        raise 'connection failed'
+      when 1
+        # ok...
+      when 2
+        password = @options[:password] or raise 'Need to authenticate but no password given'
+        challenge = socket.read CHALLENGE_SIZE
+        response = Cipher::VNCDES.new(password).encrypt(challenge)
+        socket.write response
+        ok = socket.read(4).to_s.unpack('N')[0]
+        raise 'Unable to authenticate - %p' % ok unless ok == 0
+      else
+        raise 'Unknown authentication scheme - %d' % auth
+      end
 
-			# ClientInitialisation
-			socket.write((options[:shared] ? 1 : 0).chr)
+      # ClientInitialisation
+      socket.write((options[:shared] ? 1 : 0).chr)
 
-			# ServerInitialisation
-			framebuffer_width  = socket.read(2).to_s.unpack('n')[0].to_i
-			framebuffer_height = socket.read(2).to_s.unpack('n')[0].to_i
+      # ServerInitialisation
+      framebuffer_width  = socket.read(2).to_s.unpack('n')[0].to_i
+      framebuffer_height = socket.read(2).to_s.unpack('n')[0].to_i
 
-			# TODO: parse this.
-			pixel_format = socket.read(16)
+      # TODO: parse this.
+      pixel_format = socket.read(16)
 
-			# read the name in byte chunks of 20
-			name_length = socket.read(4).to_s.unpack('N')[0]
-			hostname = [].tap do |it|
-				while name_length > 0
-					len = [20, name_length].min
-					it << socket.read(len)
-					name_length -= len
-				end
-			end.join
-		end
+      # read the name in byte chunks of 20
+      name_length = socket.read(4).to_s.unpack('N')[0]
+      hostname = [].tap do |it|
+        while name_length > 0
+          len = [20, name_length].min
+          it << socket.read(len)
+          name_length -= len
+        end
+      end.join
+    end
 
-		# this types +text+ on the server
-		def type text, options={}
-			packet = 0.chr * 8
-			packet[0] = 4.chr
-			text.split(//).each do |char|
-				packet[7] = char[0]
-				packet[1] = 1.chr
-				socket.write packet
-				packet[1] = 0.chr
-				socket.write packet
-			end
-			wait options
-		end
+    # this types +text+ on the server
+    def type text, options={}
+      packet = 0.chr * 8
+      packet[0] = 4.chr
+      text.split(//).each do |char|
+        packet[7] = char[0]
+        packet[1] = 1.chr
+        socket.write packet
+        packet[1] = 0.chr
+        socket.write packet
+      end
+      wait options
+    end
 
-		# this takes an array of keys, and successively holds each down then lifts them up in
-		# reverse order.
-		# FIXME: should wait. can't recurse in that case.
-		def key_press(*args)
-			options = Hash === args.last ? args.pop : {}
-			keys = args
-			raise ArgumentError, 'Must have at least one key argument' if keys.empty?
-			begin
-				key_down keys.first
-				if keys.length == 1
-					yield if block_given?
-				else
-					key_press(*(keys[1..-1] + [options]))
-				end
-			ensure
-				key_up keys.first
-			end
-		end
+    # this takes an array of keys, and successively holds each down then lifts them up in
+    # reverse order.
+    # FIXME: should wait. can't recurse in that case.
+    def key_press(*args)
+      options = Hash === args.last ? args.pop : {}
+      keys = args
+      raise ArgumentError, 'Must have at least one key argument' if keys.empty?
+      begin
+        key_down keys.first
+        if keys.length == 1
+          yield if block_given?
+        else
+          key_press(*(keys[1..-1] + [options]))
+        end
+      ensure
+        key_up keys.first
+      end
+    end
 
-		def get_key_code which
-			if String === which
-				if which.length != 1
-					raise ArgumentError, 'can only get key_code of single character strings'
-				end
-				which[0]
-			else
-				KEY_MAP[which]
-			end
-		end
-		private :get_key_code
+    def get_key_code which
+      if String === which
+        if which.length != 1
+          raise ArgumentError, 'can only get key_code of single character strings'
+        end
+        which[0]
+      else
+        KEY_MAP[which]
+      end
+    end
+    private :get_key_code
 
-		def key_down which, options={}
-			packet = 0.chr * 8
-			packet[0] = 4.chr
-			key_code = get_key_code which
-			packet[4, 4] = [key_code].pack('N')
-			packet[1] = 1.chr
-			socket.write packet
-			wait options
-		end
+    def key_down which, options={}
+      packet = 0.chr * 8
+      packet[0] = 4.chr
+      key_code = get_key_code which
+      packet[4, 4] = [key_code].pack('N')
+      packet[1] = 1.chr
+      socket.write packet
+      wait options
+    end
 
-		def key_up which, options={}
-			packet = 0.chr * 8
-			packet[0] = 4.chr
-			key_code = get_key_code which
-			packet[4, 4] = [key_code].pack('N')
-			packet[1] = 0.chr
-			socket.write packet
-			wait options
-		end
+    def key_up which, options={}
+      packet = 0.chr * 8
+      packet[0] = 4.chr
+      key_code = get_key_code which
+      packet[4, 4] = [key_code].pack('N')
+      packet[1] = 0.chr
+      socket.write packet
+      wait options
+    end
 
-		def pointer_move x, y, options={}
-			# options[:relative]
-			pointer.update x, y
-			wait options
-		end
+    def pointer_move x, y, options={}
+      # options[:relative]
+      pointer.update x, y
+      wait options
+    end
 
-		BUTTON_MAP = {
-			:left => 0
-		}
+    BUTTON_MAP = {
+      :left => 0
+    }
 
-		def button_press button=:left, options={}
-			begin
-				button_down button, options
-				yield if block_given?
-			ensure
-				button_up button, options
-			end
-		end
+    def button_press button=:left, options={}
+      begin
+        button_down button, options
+        yield if block_given?
+      ensure
+        button_up button, options
+      end
+    end
 
-		def button_down which=:left, options={}
-			button = BUTTON_MAP[which] || which
-			raise ArgumentError, 'Invalid button - %p' % which unless (0..2) === button
-			pointer.button |= 1 << button
-			wait options
-		end
+    def button_down which=:left, options={}
+      button = BUTTON_MAP[which] || which
+      raise ArgumentError, 'Invalid button - %p' % which unless (0..2) === button
+      pointer.button |= 1 << button
+      wait options
+    end
 
-		def button_up which=:left, options={}
-			button = BUTTON_MAP[which] || which
-			raise ArgumentError, 'Invalid button - %p' % which unless (0..2) === button
-			pointer.button &= ~(1 << button)
-			wait options
-		end
+    def button_up which=:left, options={}
+      button = BUTTON_MAP[which] || which
+      raise ArgumentError, 'Invalid button - %p' % which unless (0..2) === button
+      pointer.button &= ~(1 << button)
+      wait options
+    end
 
-		def wait options={}
-			sleep options[:wait] || @options[:wait]
-		end
+    def wait options={}
+      sleep options[:wait] || @options[:wait]
+    end
 
-		def close
-			# destroy packet reading thread
-			if @packet_reading_state == :loop
-				@packet_reading_state = :stop
-				while @packet_reading_state
-					# do nothing
-				end
-			end
-			socket.close
-		end
+    def close
+      # destroy packet reading thread
+      if @packet_reading_state == :loop
+        @packet_reading_state = :stop
+        while @packet_reading_state
+          # do nothing
+        end
+      end
+      socket.close
+    end
 
-		def clipboard
-			if block_given?
-				@clipboard = nil
-				yield
-				60.times do
-					clipboard = @mutex.synchronize { @clipboard }
-					return clipboard if clipboard
-					sleep 0.5
-				end
-				warn 'clipboard still empty after 30s'
-				nil
-			else
-				@mutex.synchronize { @clipboard }
-			end
-		end
+    def clipboard
+      if block_given?
+        @clipboard = nil
+        yield
+        60.times do
+          clipboard = @mutex.synchronize { @clipboard }
+          return clipboard if clipboard
+          sleep 0.5
+        end
+        warn 'clipboard still empty after 30s'
+        nil
+      else
+        @mutex.synchronize { @clipboard }
+      end
+    end
 
-		private
+    private
 
-		def read_packet type
-			case type
-			when 3 # ServerCutText
-				socket.read 3 # discard padding bytes
-				len = socket.read(4).unpack('N')[0]
-				@mutex.synchronize { @clipboard = socket.read len }
-			else
-				raise NotImplementedError, 'unhandled server packet type - %d' % type
-			end
-		end
+    def read_packet type
+      case type
+      when 3 # ServerCutText
+        socket.read 3 # discard padding bytes
+        len = socket.read(4).unpack('N')[0]
+        @mutex.synchronize { @clipboard = socket.read len }
+      else
+        raise NotImplementedError, 'unhandled server packet type - %d' % type
+      end
+    end
 
-		def packet_reading_thread
-			@packet_reading_state = :loop
-			loop do
-				begin
-					break if @packet_reading_state != :loop
-					next unless IO.select [socket], nil, nil, 2
-					type = socket.read(1)[0]
-					read_packet type
-				rescue
-					warn "exception in packet_reading_thread: #{$!.class}:#{$!}"
-					break
-				end
-			end
-			@packet_reading_state = nil
-		end
-	end
+    def packet_reading_thread
+      @packet_reading_state = :loop
+      loop do
+        begin
+          break if @packet_reading_state != :loop
+          next unless IO.select [socket], nil, nil, 2
+          type = socket.read(1)[0]
+          read_packet type
+        rescue
+          warn "exception in packet_reading_thread: #{$!.class}:#{$!}"
+          break
+        end
+      end
+      @packet_reading_state = nil
+    end
+  end
 end
 

--- a/lib/net/vnc/version.rb
+++ b/lib/net/vnc/version.rb
@@ -1,6 +1,6 @@
 module Net
-	class VNC
-		VERSION = '1.1.0'
-	end
+  class VNC
+    VERSION = '1.1.0'
+  end
 end
 

--- a/lib/net/vnc/version.rb
+++ b/lib/net/vnc/version.rb
@@ -1,6 +1,6 @@
 module Net
   class VNC
-    VERSION = '1.1.0'
+    VERSION = '1.1.0'.freeze
   end
 end
 

--- a/ruby-vnc.gemspec
+++ b/ruby-vnc.gemspec
@@ -4,33 +4,33 @@ PKG_NAME = 'ruby-vnc'
 PKG_VERSION = Net::VNC::VERSION
 
 Gem::Specification.new do |s|
-	s.name = PKG_NAME
-	s.version = PKG_VERSION
-	s.summary = %q{Ruby VNC library.}
-	s.description = %q{A library which implements the client VNC protocol to control VNC servers.}
-	s.authors = ['Charles Lowe']
-	s.email = %q{aquasync@gmail.com}
-	s.homepage = %q{https://github.com/aquasync/ruby-vnc}
-	s.license = %q{MIT}
-	s.rubyforge_project = %q{ruby-vnc}
+  s.name = PKG_NAME
+  s.version = PKG_VERSION
+  s.summary = %q{Ruby VNC library.}
+  s.description = %q{A library which implements the client VNC protocol to control VNC servers.}
+  s.authors = ['Charles Lowe']
+  s.email = %q{aquasync@gmail.com}
+  s.homepage = %q{https://github.com/aquasync/ruby-vnc}
+  s.license = %q{MIT}
+  s.rubyforge_project = %q{ruby-vnc}
 
-	# none yet
-	#s.executables = ['oletool']
-	s.files  = ['Rakefile', 'README.rdoc', 'COPYING', 'Changelog.rdoc', 'data/keys.yaml']
-	s.files += Dir.glob('lib/**/*.rb')
-	s.files += Dir.glob('spec/*_spec.rb')
-	# is there an rspec equivalent?
-	#s.test_files = FileList['test/test_*.rb']
+  # none yet
+  #s.executables = ['oletool']
+  s.files  = ['Rakefile', 'README.rdoc', 'COPYING', 'Changelog.rdoc', 'data/keys.yaml']
+  s.files += Dir.glob('lib/**/*.rb')
+  s.files += Dir.glob('spec/*_spec.rb')
+  # is there an rspec equivalent?
+  #s.test_files = FileList['test/test_*.rb']
 
-	s.has_rdoc = true
-	s.extra_rdoc_files = ['README.rdoc', 'Changelog.rdoc']
-	s.rdoc_options += [
-		'--main', 'README.rdoc',
-		'--title', "#{PKG_NAME} documentation",
-		'--tab-width', '2'
-	]
+  s.has_rdoc = true
+  s.extra_rdoc_files = ['README.rdoc', 'Changelog.rdoc']
+  s.rdoc_options += [
+    '--main', 'README.rdoc',
+    '--title', "#{PKG_NAME} documentation",
+    '--tab-width', '2'
+  ]
 
-	s.add_development_dependency 'rspec', '~> 3.7'
-	s.add_development_dependency 'rake', '~> 12.3'
-	s.add_development_dependency 'simplecov', '~> 0.16'
+  s.add_development_dependency 'rspec', '~> 3.7'
+  s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency 'simplecov', '~> 0.16'
 end

--- a/ruby-vnc.gemspec
+++ b/ruby-vnc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     '--tab-width', '2'
   ]
 
-  s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'simplecov', '~> 0.16'
 end

--- a/ruby-vnc.gemspec
+++ b/ruby-vnc.gemspec
@@ -6,13 +6,13 @@ PKG_VERSION = Net::VNC::VERSION
 Gem::Specification.new do |s|
   s.name = PKG_NAME
   s.version = PKG_VERSION
-  s.summary = %q{Ruby VNC library.}
-  s.description = %q{A library which implements the client VNC protocol to control VNC servers.}
+  s.summary = 'Ruby VNC library.'
+  s.description = 'A library which implements the client VNC protocol to control VNC servers.'
   s.authors = ['Charles Lowe']
-  s.email = %q{aquasync@gmail.com}
-  s.homepage = %q{https://github.com/aquasync/ruby-vnc}
-  s.license = %q{MIT}
-  s.rubyforge_project = %q{ruby-vnc}
+  s.email = 'aquasync@gmail.com'
+  s.homepage = 'https://github.com/aquasync/ruby-vnc'
+  s.license = 'MIT'
+  s.rubyforge_project = 'ruby-vnc'
 
   # none yet
   #s.executables = ['oletool']

--- a/spec/cipher_vncdes_spec.rb
+++ b/spec/cipher_vncdes_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Cipher::VNCDES do
   end
 
   it 'should correctly encrypt keys' do
-    encrypted_string = Cipher::VNCDES.new("matzisnicesowearenice").encrypt("\x9D\xBBU\n\x05b\x96L \b'&\x18\xCE(\xD8")
+    encrypted_string = Cipher::VNCDES.new('matzisnicesowearenice').encrypt("\x9D\xBBU\n\x05b\x96L \b'&\x18\xCE(\xD8")
     expect(encrypted_string.encoding.to_s).to eq 'UTF-8'
     expect(encrypted_string.size).to eq 16
     expect(encrypted_string).to eq "2\x95\xA7\xAE\xD4A\xF3\xDCt\x82d\e\xAE\x8A\xB9c"

--- a/spec/net_vnc_spec.rb
+++ b/spec/net_vnc_spec.rb
@@ -3,134 +3,134 @@ require 'net/vnc'
 
 =begin
 class SocketMock
-	class MockIOError < IOError
-	end
+  class MockIOError < IOError
+  end
 
-	def initialize
-		# this can be used to make detailed assertions
-		@trace = []
-		@read_buf  = ''
-		@write_buf = ''
-	end
+  def initialize
+    # this can be used to make detailed assertions
+    @trace = []
+    @read_buf  = ''
+    @write_buf = ''
+  end
 
-	def read len
-		@trace << [:read, len]
-		if @read_buf.length < len
-			msg = 'bad socket read sequence - read(%d) but only %d byte(s) available' % [len, @read_buf.length]
-			raise MockIOError, msg
-		end
-		@read_buf.slice! 0, len
-	end
+  def read len
+    @trace << [:read, len]
+    if @read_buf.length < len
+      msg = 'bad socket read sequence - read(%d) but only %d byte(s) available' % [len, @read_buf.length]
+      raise MockIOError, msg
+    end
+    @read_buf.slice! 0, len
+  end
 
-	def write data
-		@trace << [:write, data]
-		@write_buf << data
-	end
+  def write data
+    @trace << [:write, data]
+    @write_buf << data
+  end
 end
 
 class VNCServerSocketMock < SocketMock
-	TICK_TIME = 0.1
+  TICK_TIME = 0.1
 
-	def initialize(&block)
-		super
+  def initialize(&block)
+    super
 
-		@pending_read = nil
-		obj = self
-		@t = Thread.new { block.call obj; @pending_read = nil }
-		100.times do |i|
-			break if @pending_read
-			if i == 99
-				msg = 'blah'
-				raise MockIOError, msg
-			end
-			sleep TICK_TIME
-		end
-	end
+    @pending_read = nil
+    obj = self
+    @t = Thread.new { block.call obj; @pending_read = nil }
+    100.times do |i|
+      break if @pending_read
+      if i == 99
+        msg = 'blah'
+        raise MockIOError, msg
+      end
+      sleep TICK_TIME
+    end
+  end
 
-	def run
-		yield
-		100.times do |i|
-			break unless @pending_read
-			if i == 99
-				msg = 'missing socket write sequence'
-				raise MockIOError, msg
-			end
-			sleep TICK_TIME
-		end
-		raise 'wrote to much' if @write_buf.length != 0
-		raise 'did not read enough' if @read_buf.length != 0
-	end
+  def run
+    yield
+    100.times do |i|
+      break unless @pending_read
+      if i == 99
+        msg = 'missing socket write sequence'
+        raise MockIOError, msg
+      end
+      sleep TICK_TIME
+    end
+    raise 'wrote to much' if @write_buf.length != 0
+    raise 'did not read enough' if @read_buf.length != 0
+  end
 
-	def read len
-		@trace << [:read, len]
-		100.times do |i|
-			break if @read_buf.length >= len
-			if i == 99
-				msg = 'timeout during socket read sequence - read(%d) but only %d byte(s) available' % [len, @read_buf.length]
-				raise MockIOError, msg
-			end
-			sleep TICK_TIME
-		end
-		@read_buf.slice! 0, len
-	end
+  def read len
+    @trace << [:read, len]
+    100.times do |i|
+      break if @read_buf.length >= len
+      if i == 99
+        msg = 'timeout during socket read sequence - read(%d) but only %d byte(s) available' % [len, @read_buf.length]
+        raise MockIOError, msg
+      end
+      sleep TICK_TIME
+    end
+    @read_buf.slice! 0, len
+  end
 
-	def write data
-		unless @read_buf.empty?
-			raise MockIOError, 'tried to write with non empty read buffer - (%p, %p)' % [@read_buf, data]
-		end
-		super
-		if !@pending_read
-			raise MockIOError, "wrote to socket but server is not expecting it"
-		end
-		if @write_buf.length >= @pending_read
-			@pending_read = @write_buf.slice!(0, @pending_read)
-			sleep TICK_TIME while @pending_read.is_a? String
-		end
-	end
+  def write data
+    unless @read_buf.empty?
+      raise MockIOError, 'tried to write with non empty read buffer - (%p, %p)' % [@read_buf, data]
+    end
+    super
+    if !@pending_read
+      raise MockIOError, "wrote to socket but server is not expecting it"
+    end
+    if @write_buf.length >= @pending_read
+      @pending_read = @write_buf.slice!(0, @pending_read)
+      sleep TICK_TIME while @pending_read.is_a? String
+    end
+  end
 
-	def provide_data data
-		@read_buf << data
-	end
+  def provide_data data
+    @read_buf << data
+  end
 
-	def expect_data len
-		@pending_read = len
-		sleep TICK_TIME while @pending_read.is_a? Fixnum
-		@pending_read
-	end
+  def expect_data len
+    @pending_read = len
+    sleep TICK_TIME while @pending_read.is_a? Fixnum
+    @pending_read
+  end
 end
 
 describe 'Net::VNC' do
-	VNC = Net::VNC
+  VNC = Net::VNC
 
-	it 'should do something' do
+  it 'should do something' do
 =begin
-		socket_mock.should_receive(:read).once.ordered.with(12).and_return("RFB 003.003\n")
-		socket_mock.should_receive(:write).once.ordered.with(/^RFB (\d{3}.\d{3})\n$/)
-		socket_mock.should_receive(:read).once.ordered.with(4).and_return([1].pack('N'))
-		socket_mock.should_receive(:write).once.ordered.with("\000")
-		socket_mock.should_receive(:read).once.ordered.with(20).and_return('')
-		socket_mock.should_receive(:read).once.ordered.with(4).and_return([0].pack('N'))
-		#m = mock('my mock')
-		#m.should_receive(:test1).ordered.once.with('argument').and_return(1)
-		#m.should_receive(:test2).ordered.once.with('argument').and_return(2)
-		#p m.test1('argument')
-		#p m.test2('argument')
-		vnc = VNC.open('192.168.0.1:0')
+    socket_mock.should_receive(:read).once.ordered.with(12).and_return("RFB 003.003\n")
+    socket_mock.should_receive(:write).once.ordered.with(/^RFB (\d{3}.\d{3})\n$/)
+    socket_mock.should_receive(:read).once.ordered.with(4).and_return([1].pack('N'))
+    socket_mock.should_receive(:write).once.ordered.with("\000")
+    socket_mock.should_receive(:read).once.ordered.with(20).and_return('')
+    socket_mock.should_receive(:read).once.ordered.with(4).and_return([0].pack('N'))
+    #m = mock('my mock')
+    #m.should_receive(:test1).ordered.once.with('argument').and_return(1)
+    #m.should_receive(:test2).ordered.once.with('argument').and_return(2)
+    #p m.test1('argument')
+    #p m.test2('argument')
+    vnc = VNC.open('192.168.0.1:0')
 #=end
 
-		server = VNCServerSocketMock.new do |s|
-			s.provide_data "RFB 003.003\n"
-			p :read => s.expect_data(12)
-			s.provide_data [1].pack('N')
-			p :read => s.expect_data(1)
-			s.provide_data ' ' * 20
-			s.provide_data [0].pack('N')
-		end
-		server.run do
-			TCPSocket.should_receive(:open).with('192.168.0.1', 5900).and_return(server)
-			vnc = VNC.open('192.168.0.1:0')
-		end
-	end
+    server = VNCServerSocketMock.new do |s|
+      s.provide_data "RFB 003.003\n"
+      p :read => s.expect_data(12)
+      s.provide_data [1].pack('N')
+      p :read => s.expect_data(1)
+      s.provide_data ' ' * 20
+      s.provide_data [0].pack('N')
+    end
+    server.run do
+      TCPSocket.should_receive(:open).with('192.168.0.1', 5900).and_return(server)
+      vnc = VNC.open('192.168.0.1:0')
+    end
+  end
 end
 =end
 

--- a/spec/real_net_vnc_spec.rb
+++ b/spec/real_net_vnc_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Net::VNC do
   context 'no auth' do
     it 'should connect with no password' do
       Net::VNC.open(NO_AUTH_SERVER_DISPLAY) do |vnc|
-        vnc.pointer_move(10,15)
+        vnc.pointer_move(10, 15)
         expect(vnc.pointer.x).to eq 10
         expect(vnc.pointer.y).to eq 15
 
-        vnc.pointer_move(20,25)
+        vnc.pointer_move(20, 25)
         expect(vnc.pointer.x).to eq 20
         expect(vnc.pointer.y).to eq 25
       end
@@ -20,7 +20,7 @@ RSpec.describe Net::VNC do
 
     it 'should connect with password even though it is not needed' do
       Net::VNC.open(NO_AUTH_SERVER_DISPLAY, password: 'password') do |vnc|
-        vnc.pointer_move(10,15)
+        vnc.pointer_move(10, 15)
         expect(vnc.pointer.x).to eq 10
       end
     end
@@ -29,7 +29,7 @@ RSpec.describe Net::VNC do
   context 'with auth' do
     it 'should connect with a password' do
       Net::VNC.open(WITH_AUTH_SERVER_DISPLAY, password: 'matzisnicesowearenice') do |vnc|
-        vnc.pointer_move(10,15)
+        vnc.pointer_move(10, 15)
         expect(vnc.pointer.x).to eq 10
         expect(vnc.pointer.y).to eq 15
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,7 +58,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -78,7 +78,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
Small fixes, mostly it is changing the tabs to spaces, `.freeze` some strings, and use `'` instead of `"` for strings where interpolation or byte-sequences is not used. 

It was done running Rubocop with default rules: `rubocop --auto-gen-config --auto-correct`