### PR TITLE
bugfix get_key_code() returns ASCII CODE as RFB key code

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -188,7 +188,7 @@ module Net
         if which.length != 1
           raise ArgumentError, 'can only get key_code of single character strings'
         end
-        which[0]
+        which[0].ord
       else
         KEY_MAP[which]
       end


### PR DESCRIPTION
Hi, I try use this OSS for my product.

But I got `Type Error` using `key_down 'a'`.

sample code:
```
require 'net/vnc'
Net::VNC.open 'localhost:2', :shared => true, :password => 'matzisnicesowearenice' do |vnc|
  key_down 'a'
  key_up 'a'
end
```

result:
```
Traceback (most recent call last):
        4: from aaa.rb:2:in `<main>'
        3: from /usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ruby-vnc-1.1.0/lib/net/vnc.rb:92:in `open'
        2: from aaa.rb:5:in `block in <main>'
        1: from /usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ruby-vnc-1.1.0/lib/net/vnc.rb:196:in `key_down'
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/ruby-vnc-1.1.0/lib/net/vnc.rb:196:in `pack': no implicit conversion of String into Integer (TypeError)
```
