### PR TITLE
add `clipboard=` method

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -279,7 +279,7 @@ module Net
       end
     end
 
-    def copy_text_to_clipboard text
+    def clipboard= text
       text = text.to_s.gsub(/\R/, "\n") # eol of ClientCutText's text is LF
       byte_size = text.to_s.bytes.size
       packet = 0.chr * (8 + byte_size)

--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -287,6 +287,7 @@ module Net
       packet[4, 4] = [byte_size].pack('N') # length
       packet[8, byte_size] = text
       socket.write(packet)
+      @clipboard = text
     end
 
     private

--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -279,6 +279,16 @@ module Net
       end
     end
 
+    def copy_text_to_clipboard text
+      text = text.to_s.gsub(/\R/, "\n") # eol of ClientCutText's text is LF
+      byte_size = text.to_s.bytes.size
+      packet = 0.chr * (8 + byte_size)
+      packet[0] = 6.chr # message-type: 6 (ClientCutText)
+      packet[4, 4] = [byte_size].pack('N') # length
+      packet[8, byte_size] = text
+      socket.write(packet)
+    end
+
     private
 
     def read_packet type


### PR DESCRIPTION
I added a method to send the `ClientCutText` message of RFB Protocol.
This makes us copy text to the clipboard.