### PR TITLE
Gemspec.has_rdoc has been deprecated

### DIFF
--- a/ruby-vnc.gemspec
+++ b/ruby-vnc.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   # is there an rspec equivalent?
   #s.test_files = FileList['test/test_*.rb']
 
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'Changelog.rdoc']
   s.rdoc_options += [
     '--main', 'README.rdoc',


### PR DESCRIPTION
When bundling with a newer Rubygems, I get this warning:

```bash
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. 
It will be removed on or after 2018-12-01.
```