### PR TITLE
Preventing VNC servers from sending unhandled server packets

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -151,6 +151,8 @@ module Net
           name_length -= len
         end
       end.join
+
+      _load_frame_buffer
     end
 
     # this types +text+ on the server


### PR DESCRIPTION
I use UltraVNC. Sometimes it sends variable unhandled server packets.
ruby-vnc don't handle the packet types, so it raises `NotImplementedError` exception...
I need stopping it.

lib/net/vnc.rb
```ruby
    def read_packet type
      case type
      ...
      else
        raise NotImplementedError, 'unhandled server packet type - %d' % type
      end
    end
```

Error message
```
/usr/local/lib/ruby/gems/2.5.0/gems/ruby-vnc-1.1.0/lib/net/vnc.rb:333:in `read_packet':
unhandled server packet type - 7 (NotImplementedError)

* packet type is variable. For other packet type example: 6, 8, 17 ... and so on
```

Once sending "client to server messages", VNC servers will send only messages which client can handle.
So, we need to send initial data on connection.
https://vncdotool.readthedocs.io/en/0.8.0/rfbproto.html#client-to-server-messages