### PR TITLE
Not raise exception but just warn when receiving unhandled server packets

### DIFF
--- a/lib/net/vnc.rb
+++ b/lib/net/vnc.rb
@@ -330,7 +330,7 @@ module Net
         len = socket.read(4).unpack('N')[0]
         @mutex.synchronize { @clipboard = socket.read len }
       else
-        raise NotImplementedError, 'unhandled server packet type - %d' % type
+        warn 'unhandled server packet type - %d' % type
       end
     end
 


### PR DESCRIPTION
Related to #21.

For now, when receiving unhandled server packets, ruby-vnc raise exception.
But I think it should not raise exception but just output warning message because they are only unhandled and do nothing.