### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/ruby-vnc.gemspec
+++ b/ruby-vnc.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.email = 'aquasync@gmail.com'
   s.homepage = 'https://github.com/aquasync/ruby-vnc'
   s.license = 'MIT'
-  s.rubyforge_project = 'ruby-vnc'
 
   # none yet
   #s.executables = ['oletool']


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.